### PR TITLE
More idiomatic tests and test error messages

### DIFF
--- a/pkg/actions/shell_action_test.go
+++ b/pkg/actions/shell_action_test.go
@@ -16,8 +16,8 @@ func TestShellCommandAction_Run_Success(t *testing.T) {
 }
 
 func TestShellCommandAction_Run_Writer(t *testing.T) {
-	expected := "foo"
-	cmd := NewShellCommandAction("echo " + expected)
+	want := "foo"
+	cmd := NewShellCommandAction("echo " + want)
 	buf := new(bytes.Buffer)
 	cmd.outputWriter = buf
 
@@ -26,9 +26,9 @@ func TestShellCommandAction_Run_Writer(t *testing.T) {
 		t.Errorf("command failed: %s", err)
 	}
 
-	stdout := strings.TrimSpace(buf.String())
-	if stdout != expected {
-		t.Errorf("expected STDOUT to be '%s'; got '%s'", expected, stdout)
+	stdout := buf.String()
+	if !strings.Contains(stdout, want) {
+		t.Errorf("wanted STDOUT to contain '%s'; got '%s'", want, stdout)
 	}
 }
 
@@ -37,22 +37,21 @@ func TestShellCommandAction_Run_Fail(t *testing.T) {
 
 	err := cmd.Run()
 	if err == nil {
-		t.Fatal("expected command to fail with non-zero exit code")
+		t.Fatal("wanted command to fail with non-zero exit code")
 	}
 
-	expected := "shell_action: exit status 1"
-	if expected != err.Error() {
-		t.Errorf("expected error message %s; got %s", expected, err.Error())
+	want := "shell_action"
+	if !strings.HasPrefix(err.Error(), want) {
+		t.Errorf("wanted error prefix %s; got %s", want, err.Error())
 	}
 }
 
 func TestShellCommandAction_String(t *testing.T) {
-	cmd := NewShellCommandAction("foo bar")
+	command := "foo bar"
+	cmd := NewShellCommandAction(command)
 
-	expected := "[sh]: foo bar"
-	actual := cmd.String()
-
-	if actual != expected {
-		t.Errorf("expected %s, got %s", expected, actual)
+	wanted := "[sh]: " + command
+	if wanted != cmd.String() {
+		t.Errorf("wanted %s, got %s", wanted, cmd)
 	}
 }

--- a/pkg/dependency_test.go
+++ b/pkg/dependency_test.go
@@ -19,11 +19,11 @@ func TestDependency_Satisfy_StateKnown(t *testing.T) {
 		dep.State = state
 		errs := dep.Satisfy()
 		if len(errs) > 0 {
-			t.Errorf("was not expecting errors; got %s", errs)
+			t.Errorf("wanted no errors; got %s", errs)
 		}
 
 		if action.count != 0 {
-			t.Errorf("action was called %d times; expected 0", action.count)
+			t.Errorf("wanted action called 0 times; called %d times0", action.count)
 		}
 	}
 }
@@ -33,11 +33,11 @@ func TestDependency_Satisfy_NoDepsOrActions(t *testing.T) {
 
 	errs := dep.Satisfy()
 	if len(errs) > 0 {
-		t.Errorf("was not expecting errors; got %s", errs)
+		t.Errorf("wanted no errors; got %s", errs)
 	}
 
 	if dep.State != satisfied {
-		t.Errorf("was expecting state satisfied; got %s", dep.State)
+		t.Errorf("wanted state satisfied; got %s", dep.State)
 	}
 }
 
@@ -54,15 +54,15 @@ func TestDependency_Satisfy_DepsCachedUnsatisfied(t *testing.T) {
 
 	errs := foo.Satisfy()
 	if len(errs) > 0 {
-		t.Errorf("was not expecting errors; got %s", errs)
+		t.Errorf("wanted no errors; got %s", errs)
 	}
 
 	if foo.State != unsatisfied {
-		t.Errorf("was expecting state unsatisfied; got %s", foo.State)
+		t.Errorf("wanted state unsatisfied; got %s", foo.State)
 	}
 
 	if action.count > 0 {
-		t.Errorf("action was called %d times; expected 0", action.count)
+		t.Errorf("wanted action called 0 times; called %d times", action.count)
 	}
 }
 
@@ -81,21 +81,21 @@ func TestDependency_Satisfy_DepsMeetActionFails(t *testing.T) {
 
 	errs := foo.Satisfy()
 	if len(errs) != 1 {
-		t.Errorf("was expecting 1 error; got %d", len(errs))
+		t.Errorf("wanted 1 error; got %d", len(errs))
 	}
 
-	actual := errs[0].Error()
-	expected := fmt.Sprintf("meet action: %s", err)
-	if expected != actual {
-		t.Errorf("expected %s; got %s", expected, actual)
+	want := fmt.Sprintf("meet action: %s", err)
+	got := errs[0].Error()
+	if want != got {
+		t.Errorf("wanted %s; got %s", want, got)
 	}
 
 	if foo.State != unsatisfied {
-		t.Errorf("was expecting state unsatisfied; got %s", foo.State)
+		t.Errorf("wanted state unsatisfied; got %s", foo.State)
 	}
 
 	if action.count > 0 {
-		t.Errorf("action was called %d times; expected 0", action.count)
+		t.Errorf("wanted action called 0 times; called %d times", action.count)
 	}
 }
 
@@ -110,19 +110,19 @@ func TestDependency_Satisfy_MetActionFailsThenSucceeds(t *testing.T) {
 
 	errs := dep.Satisfy()
 	if len(errs) > 0 {
-		t.Errorf("was not expecting errors; got %s", errs)
+		t.Errorf("wanted no errors; got %s", errs)
 	}
 
 	if dep.State != satisfied {
-		t.Errorf("was expecting state satisfied; got %s", dep.State)
+		t.Errorf("wanted state satisfied; got %s", dep.State)
 	}
 
 	if metAction.count != 2 {
-		t.Errorf("was expecting metAction to be called twice; called %d times", metAction.count)
+		t.Errorf("wanted metAction to be called twice; called %d times", metAction.count)
 	}
 
 	if meetAction.count != 1 {
-		t.Errorf("was expecting meetAction to be called once; called %d times", meetAction.count)
+		t.Errorf("wanted meetAction to be called once; called %d times", meetAction.count)
 	}
 }
 
@@ -137,19 +137,19 @@ func TestDependency_Satisfy_MetActionSucceeds(t *testing.T) {
 
 	errs := dep.Satisfy()
 	if len(errs) > 0 {
-		t.Errorf("not expecting errors; got %s", errs)
+		t.Errorf("wanted no errors; got %s", errs)
 	}
 
 	if dep.State != satisfied {
-		t.Errorf("expecting state satisfied; got %s", dep.State)
+		t.Errorf("wanted state satisfied; got %s", dep.State)
 	}
 
 	if meetAction.count > 0 {
-		t.Errorf("expecting meet action to be called; was called %d times", meetAction.count)
+		t.Errorf("wanted action to not be called; called %d times", meetAction.count)
 	}
 
 	if metAction.count != 1 {
-		t.Errorf("expecting met action to be called once; was called %d times", metAction.count)
+		t.Errorf("wanted met action to be called once; called %d times", metAction.count)
 	}
 }
 
@@ -165,25 +165,25 @@ func TestDependency_Satisfy_MetActionSucceeds_MeetActionFails(t *testing.T) {
 
 	errs := dep.Satisfy()
 	if len(errs) != 1 {
-		t.Errorf("expecting one error; got %d", len(errs))
+		t.Errorf("wanted one error; got %d", len(errs))
 	}
 
 	if dep.State != unsatisfied {
-		t.Errorf("expecting state unsatisfied; got %s", dep.State)
+		t.Errorf("wanted state unsatisfied; got %s", dep.State)
 	}
 
-	expected := fmt.Sprintf("meet action: %s", err)
-	actual := errs[0].Error()
-	if expected != actual {
-		t.Errorf("expected %s; got %s", expected, actual)
+	want := fmt.Sprintf("meet action: %s", err)
+	got := errs[0].Error()
+	if want != got {
+		t.Errorf("wanted %s; got %s", want, got)
 	}
 
 	if meetAction.count != 1 {
-		t.Errorf("expecting meet action to be once; was called %d times", meetAction.count)
+		t.Errorf("wanted meet action to be called once; called %d times", meetAction.count)
 	}
 
 	if metAction.count != 1 {
-		t.Errorf("expecting met action to be called once; was called %d times", metAction.count)
+		t.Errorf("wanted met action to be called once; called %d times", metAction.count)
 	}
 }
 

--- a/pkg/graph_test.go
+++ b/pkg/graph_test.go
@@ -32,7 +32,7 @@ func TestDependencyGraph_Construct(t *testing.T) {
 	}
 
 	if len(fooDep.Dependencies) != 0 {
-		t.Errorf("expected no deps for foo; got %d", len(fooDep.Dependencies))
+		t.Errorf("wanted no deps for foo; got %d", len(fooDep.Dependencies))
 	}
 
 	// bar is well formed
@@ -44,31 +44,31 @@ func TestDependencyGraph_Construct(t *testing.T) {
 	}
 
 	if len(barDep.Dependencies) != 1 {
-		t.Errorf("expected requirements slice to be of size 1; got %d", len(barDep.Dependencies))
+		t.Errorf("wanted requirements slice to be of size 1; got %d", len(barDep.Dependencies))
 	}
 
 	if barDep.Dependencies[0] != fooDep {
-		t.Errorf("expected bar's only dep to be foo; was %v", barDep.Dependencies[0])
+		t.Errorf("wanted bar's only dep to be foo; got %v", barDep.Dependencies[0])
 	}
 
 	// converter map should contain only the deps foo and bar
 
 	if len(g.depMap) != 2 {
-		t.Errorf("expected map to be of size 2; was %d", len(g.depMap))
+		t.Errorf("wanted map to be of size 2; got %d", len(g.depMap))
 	}
 
 	assertMapContainsDep(t, g, "foo", fooDep)
 	assertMapContainsDep(t, g, "bar", barDep)
 }
 
-func assertMapContainsDep(t *testing.T, g *DependencyGraph, depName string, expectedDep *Dependency) {
+func assertMapContainsDep(t *testing.T, g *DependencyGraph, depName string, wantedDep *Dependency) {
 	dep, found := g.depMap[depName]
 
 	if !found {
-		t.Errorf("expected map to contain key '%s'", depName)
+		t.Errorf("wanted map to contain key '%s'; got %+v", depName, g.depMap)
 	}
 
-	if dep != expectedDep {
-		t.Errorf("expected '%s' key to be dep %s; was %v", depName, expectedDep.Name, dep)
+	if dep != wantedDep {
+		t.Errorf("wanted '%s' key to be dep %s; was %+v", depName, wantedDep.Name, dep)
 	}
 }

--- a/pkg/lang/dep.go
+++ b/pkg/lang/dep.go
@@ -1,7 +1,6 @@
 package lang
 
 import (
-	"errors"
 	"fmt"
 
 	"go.starlark.net/starlark"
@@ -155,7 +154,7 @@ func FnDep(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs
 func asString(value starlark.Value) (string, error) {
 	str, ok := value.(starlark.String)
 	if !ok {
-		return "", errors.New(fmt.Sprintf("value %v is not a string", value))
+		return "", fmt.Errorf("value %v is not a string", value)
 	}
 	return string(str), nil
 }
@@ -165,7 +164,7 @@ func asString(value starlark.Value) (string, error) {
 func asRequirementsList(value starlark.Value) ([]*Dep, error) {
 	list, ok := value.(*starlark.List)
 	if !ok {
-		return nil, errors.New(fmt.Sprintf("value %v is not a list", value))
+		return nil, fmt.Errorf("value %v is not a list", value)
 	}
 
 	var deps []*Dep
@@ -177,7 +176,7 @@ func asRequirementsList(value starlark.Value) ([]*Dep, error) {
 	for iter.Next(&v) {
 		dep, ok := v.(*Dep)
 		if !ok {
-			return nil, errors.New(fmt.Sprintf("value %v is not a dep", v))
+			return nil, fmt.Errorf("value %v is not a dep", v)
 		}
 		deps = append(deps, dep)
 	}
@@ -190,7 +189,7 @@ func asRequirementsList(value starlark.Value) ([]*Dep, error) {
 func asCommandList(value starlark.Value) ([]*ShellCmd, error) {
 	list, ok := value.(*starlark.List)
 	if !ok {
-		return nil, errors.New(fmt.Sprintf("value %v is not a list", value))
+		return nil, fmt.Errorf("value %+v is not a list", value)
 	}
 
 	var commands []*ShellCmd
@@ -202,7 +201,7 @@ func asCommandList(value starlark.Value) ([]*ShellCmd, error) {
 	for iter.Next(&v) {
 		command, ok := v.(ShellCmd)
 		if !ok {
-			return nil, errors.New(fmt.Sprintf("list item %v is not a command", v))
+			return nil, fmt.Errorf("list item %+v is not a command", v)
 		}
 		commands = append(commands, &command)
 	}

--- a/pkg/lang/dep_test.go
+++ b/pkg/lang/dep_test.go
@@ -11,22 +11,19 @@ import (
 func TestDep_String(t *testing.T) {
 	dep := Dep{Name: "foo"}
 
-	expected := "<dep.Dep \"foo\">"
-	actual := dep.String()
-
-	if expected != actual {
-		t.Errorf("wanted %s, got %s", expected, actual)
+	want := "<dep.Dep \"foo\">"
+	if want != dep.String() {
+		t.Errorf("want %+v, got %+v", want, dep)
 	}
 }
 
 func TestDep_Type(t *testing.T) {
 	dep := Dep{}
 
-	expected := "dep.Dep"
-	actual := dep.Type()
-
-	if expected != actual {
-		t.Errorf("wanted %s, got %s", expected, actual)
+	want := "dep.Dep"
+	got := dep.Type()
+	if want != got {
+		t.Errorf("want %s, got %s", want, got)
 	}
 }
 
@@ -44,25 +41,25 @@ func TestDep_Hash(t *testing.T) {
 	_, err := dep.Hash()
 
 	if err == nil {
-		t.Fatal("expected Hash to return an error")
+		t.Fatal("wanted Hash to return an error")
 	}
 
-	if !strings.Contains(err.Error(), "unhashable type") {
-		t.Errorf("expected error to contain 'unhashable type")
+	if !strings.HasPrefix(err.Error(), "unhashable type") {
+		t.Errorf("wanted error to contain 'unhashable type")
 	}
 }
 
 func TestAsString(t *testing.T) {
-	expected := "foo"
-	value := starlark.String(expected)
-	actual, err := asString(value)
+	want := "foo"
+	value := starlark.String(want)
+	got, err := asString(value)
 
 	if err != nil {
 		t.Errorf("could not parse starlark string")
 	}
 
-	if expected != actual {
-		t.Errorf("wanted %s, got %s", expected, actual)
+	if want != got {
+		t.Errorf("want %s, got %s", want, got)
 	}
 }
 
@@ -77,7 +74,7 @@ func TestAsString_NotString(t *testing.T) {
 	for _, value := range values {
 		_, err := asString(value)
 		if err == nil {
-			t.Errorf("expected error parsing value %v to a string", value)
+			t.Errorf("wanted error parsing value %+v to a string", value)
 		}
 	}
 }
@@ -99,9 +96,9 @@ func TestAsRequirementsList(t *testing.T) {
 	}
 
 	for i, item := range list {
-		expected := depItems[i]
-		if expected != item {
-			t.Errorf("wanted %s, got %s", expected, item)
+		want := depItems[i]
+		if want != item {
+			t.Errorf("want %+v, got %+v", want, item)
 		}
 	}
 }
@@ -116,11 +113,11 @@ func TestAsRequirementsList_NotDep(t *testing.T) {
 	for _, list := range lists {
 		_, err := asRequirementsList(list)
 		if err == nil {
-			t.Fatal("expected error")
+			t.Fatal("wanted error")
 		}
 
 		if !strings.Contains(err.Error(), "is not a dep") {
-			t.Error("expected error message to contain 'is not a dep'")
+			t.Error("wanted error message to contain 'is not a dep'")
 		}
 	}
 }
@@ -135,11 +132,11 @@ func TestAsRequirementsList_NotList(t *testing.T) {
 	for _, value := range values {
 		_, err := asRequirementsList(value)
 		if err == nil {
-			t.Fatalf("expected error parsing %s as a list", value)
+			t.Fatalf("wanted error parsing %s as a list", value)
 		}
 
 		if !strings.Contains(err.Error(), "is not a list") {
-			t.Errorf("expected error message to contain 'is not a list'")
+			t.Errorf("wanted error message to contain 'is not a list'")
 		}
 	}
 }
@@ -161,9 +158,10 @@ func TestAsCommandList(t *testing.T) {
 	}
 
 	for i, item := range list {
-		expected := cmdItems[i].Command
-		if expected != item.Command {
-			t.Errorf("wanted %s, got %s", expected, item)
+		want := cmdItems[i].Command
+		got := item.Command
+		if want != got {
+			t.Errorf("want %+v, got %+v", want, got)
 		}
 	}
 }
@@ -178,11 +176,11 @@ func TestAsCommandList_NotDep(t *testing.T) {
 	for _, list := range lists {
 		_, err := asCommandList(list)
 		if err == nil {
-			t.Fatal("expected error")
+			t.Fatal("wanted error")
 		}
 
 		if !strings.Contains(err.Error(), "is not a command") {
-			t.Error("expected error message to contain 'is not a command'")
+			t.Error("wanted error message to contain 'is not a command'")
 		}
 	}
 }
@@ -197,11 +195,11 @@ func TestAsCommandList_NotList(t *testing.T) {
 	for _, value := range values {
 		_, err := asCommandList(value)
 		if err == nil {
-			t.Fatalf("expected error parsing %s as a list", value)
+			t.Fatalf("wanted error parsing %s as a list", value)
 		}
 
 		if !strings.Contains(err.Error(), "is not a list") {
-			t.Errorf("expected error message to contain 'is not a list'")
+			t.Errorf("wanted error message to contain 'is not a list'")
 		}
 	}
 }

--- a/pkg/lang/parser_test.go
+++ b/pkg/lang/parser_test.go
@@ -17,11 +17,11 @@ func TestParser_NoMain(t *testing.T) {
 
 	err := parser.Run()
 	if err == nil {
-		t.Fatalf("expected an erorr")
+		t.Fatalf("wanted an erorr")
 	}
 
 	if err.Error() != "main.dep not found" {
-		t.Errorf("expected error 'main.dep not found'")
+		t.Errorf("wanted error 'main.dep not found'")
 	}
 }
 
@@ -35,12 +35,12 @@ func TestParser_SimpleMain(t *testing.T) {
 
 	modules := parser.Modules()
 	if len(modules) != 1 {
-		t.Errorf("expected 1 file , got %d", len(modules))
+		t.Errorf("wanted 1 file , got %d", len(modules))
 	}
 
 	main := modules[0]
 	if len(main.Keys()) != 2 {
-		t.Errorf("expected 2 variables in main.dep, got %d", len(main.Keys()))
+		t.Errorf("wanted 2 variables in main.dep, got %d", len(main.Keys()))
 	}
 
 	// Check the "all" Dep
@@ -56,68 +56,68 @@ func TestParser_SimpleMain(t *testing.T) {
 	}
 
 	if dep.Name != "all" {
-		t.Errorf("Name of Dep 'all' was not 'all'; was %s", dep.Name)
+		t.Errorf("name of Dep 'all' was not 'all'; got %s", dep.Name)
 	}
 
 	if len(dep.Requirements) != 1 {
-		t.Errorf("Expected Dep 'all' to have 1 requirement; had %d", len(dep.Requirements))
+		t.Errorf("wanted Dep 'all' to have 1 requirement; got %d", len(dep.Requirements))
 	}
 
 	if dep.Requirements[0].Name != "foo" {
-		t.Errorf("Expected Dep 'all' to have requirement 'foo'; had '%s'", dep.Requirements[0])
+		t.Errorf("wanted Dep 'all' to have requirement 'foo'; got '%s'", dep.Requirements[0])
 	}
 
 	if len(dep.MetCommands) != 1 {
-		t.Errorf("Expected Dep 'all' to have 1 'met' command; had %d", len(dep.MetCommands))
+		t.Errorf("wanted Dep 'all' to have 1 'met' command; got %d", len(dep.MetCommands))
 	}
 
-	expected := "echo 'Hello, world!'"
-	actual := dep.MetCommands[0].Command
+	want := "echo 'Hello, world!'"
+	got := dep.MetCommands[0].Command
 	if dep.MetCommands[0].Command != "echo 'Hello, world!'" {
-		t.Errorf("Expected Dep 'all' 'met' command to be '%s'; was '%s'", expected, actual)
+		t.Errorf("wanted Dep 'all' 'met' command to be '%s'; got '%s'", want, got)
 	}
 
 	if len(dep.MeetCommands) != 2 {
-		t.Errorf("Expected Dep 'all' to have 2 'meet' command; had %d", len(dep.MeetCommands))
+		t.Errorf("wanted Dep 'all' to have 2 'meet' command; got %d", len(dep.MeetCommands))
 	}
 
-	expected = "echo 'Hello, indeed!'"
-	actual = dep.MeetCommands[0].Command
-	if expected != actual {
-		t.Errorf("Expected Dep 'all' 'meet' command #1 to be '%s'; was '%s'", expected, actual)
+	want = "echo 'Hello, indeed!'"
+	got = dep.MeetCommands[0].Command
+	if want != got {
+		t.Errorf("wanted Dep 'all' 'meet' command #1 to be '%s'; got '%s'", want, got)
 	}
 
-	expected = "echo 'Hello, again!'"
-	actual = dep.MeetCommands[1].Command
-	if expected != actual {
-		t.Errorf("Expected Dep 'all' 'meet' command #2 to be '%s'; was '%s'", expected, actual)
+	want = "echo 'Hello, again!'"
+	got = dep.MeetCommands[1].Command
+	if want != got {
+		t.Errorf("wanted Dep 'all' 'meet' command #2 to be '%s'; got '%s'", want, got)
 	}
 
 	// Check the "foo" Dep
 
 	foo, ok := main["foo"]
 	if !ok {
-		t.Errorf("main.dep does to have dep 'foo'")
+		t.Errorf("wanted main.dep to have dep 'foo'")
 	}
 
 	dep, ok = foo.(*Dep)
 	if !ok {
-		t.Errorf("'foo' was not a Dep")
+		t.Errorf("wanted 'foo' to be a Dep")
 	}
 	if dep.Name != "foo" {
-		t.Errorf("Name of Dep 'foo' was not 'foo'; was %s", dep.Name)
+		t.Errorf("wanted name of Dep 'foo' to be 'foo'; got %s", dep.Name)
 	}
 
 	if len(dep.Requirements) != 0 {
-		t.Errorf("Expected Dep 'foo' to have 0 requirement; had %d", len(dep.Requirements))
+		t.Errorf("wanted Dep 'foo' to have 0 requirement; got %d", len(dep.Requirements))
 	}
 
 	if len(dep.MetCommands) != 0 {
-		t.Errorf("Expected Dep 'foo' to have 0 'met' command; had %d", len(dep.MetCommands))
+		t.Errorf("wanted Dep 'foo' to have 0 'met' command; got %d", len(dep.MetCommands))
 	}
 
 	if len(dep.MeetCommands) != 0 {
-		t.Errorf("Expected Dep 'foo' to have 0 'meet' command; had %d", len(dep.MeetCommands))
+		t.Errorf("wanted Dep 'foo' to have 0 'meet' command; got %d", len(dep.MeetCommands))
 	}
 }
 
@@ -126,19 +126,19 @@ func TestParser_MultiFile(t *testing.T) {
 
 	err := parser.Run()
 	if err != nil {
-		t.Errorf("did not expect error %s", err)
+		t.Errorf("parser.Run: %s", err)
 	}
 
 	modules := parser.Modules()
 	if len(modules) != 4 {
-		t.Errorf("expected 4 file , got %d", len(modules))
+		t.Errorf("wanted 4 files, got %d", len(modules))
 	}
 
 	depMap := toMap(modules)
-	expectedGlobals := []string{"all", "foo", "bar", "baz", "bam"}
-	for _, expected := range expectedGlobals {
-		if _, contains := depMap[expected]; !contains {
-			t.Errorf("expected module %s in module %v", expectedGlobals, modules)
+	wantedGlobals := []string{"all", "foo", "bar", "baz", "bam"}
+	for _, want := range wantedGlobals {
+		if _, contains := depMap[want]; !contains {
+			t.Errorf("wanted module %s in module %+v", wantedGlobals, modules)
 		}
 	}
 
@@ -146,43 +146,43 @@ func TestParser_MultiFile(t *testing.T) {
 
 	dep := depMap["all"]
 	if !contains("foo", dep.Requirements) {
-		t.Errorf("expected Dep 'all' to require 'foo'")
+		t.Errorf("wanted Dep 'all' to require 'foo'")
 	}
 
 	if !contains("bar", dep.Requirements) {
-		t.Errorf("expected Dep 'all' to require 'bar'")
+		t.Errorf("wanted Dep 'all' to require 'bar'")
 	}
 
 	if !contains("baz", dep.Requirements) {
-		t.Errorf("expected Dep 'all' to require 'baz'")
+		t.Errorf("wanted Dep 'all' to require 'baz'")
 	}
 
 	// foo depends on bam
 
 	dep = depMap["foo"]
 	if !contains("bam", dep.Requirements) {
-		t.Errorf("expected Dep 'foo' to require 'bam'")
+		t.Errorf("wanted Dep 'foo' to require 'bam'")
 	}
 
 	// bar depends on baz
 
 	dep = depMap["bar"]
 	if !contains("baz", dep.Requirements) {
-		t.Errorf("expected Dep 'bar' to require 'baz'")
+		t.Errorf("wanted Dep 'bar' to require 'baz'")
 	}
 
 	// baz depends on nothing
 
 	dep = depMap["baz"]
 	if len(dep.Requirements) != 0 {
-		t.Errorf("expected Dep 'baz' to depend on nothing; got %s", dep.Requirements)
+		t.Errorf("wanted Dep 'baz' to depend on nothing; got %s", dep.Requirements)
 	}
 
 	// bam depends on baz
 
 	dep = depMap["bam"]
 	if !contains("baz", dep.Requirements) {
-		t.Errorf("expected Dep 'bam' to require 'baz'")
+		t.Errorf("wanted Dep 'bam' to require 'baz'")
 	}
 }
 
@@ -202,9 +202,9 @@ func toMap(modules []starlark.StringDict) map[string]*Dep {
 	return depMap
 }
 
-func contains(expected string, requirements []*Dep) bool {
+func contains(want string, requirements []*Dep) bool {
 	for _, req := range requirements {
-		if req.Name == expected {
+		if req.Name == want {
 			return true
 		}
 	}

--- a/pkg/lang/shell.go
+++ b/pkg/lang/shell.go
@@ -1,7 +1,6 @@
 package lang
 
 import (
-	"errors"
 	"fmt"
 
 	"go.starlark.net/starlark"
@@ -52,7 +51,7 @@ func FnShell(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwar
 	value := args.Index(0)
 	strValue, ok := value.(starlark.String)
 	if !ok {
-		return nil, errors.New(fmt.Sprintf("expected %v to be ok type String", value))
+		return nil, fmt.Errorf("expected %v to be ok type String", value)
 	}
 
 	shell := ShellCmd{

--- a/pkg/lang/shell_test.go
+++ b/pkg/lang/shell_test.go
@@ -10,22 +10,22 @@ import (
 func TestString(t *testing.T) {
 	cmd := ShellCmd{"foo"}
 
-	expected := "<dep.ShellCmd \"foo\">"
-	actual := cmd.String()
+	wanted := "<dep.ShellCmd \"foo\">"
+	got := cmd.String()
 
-	if expected != actual {
-		t.Errorf("wanted %s, got %s", expected, actual)
+	if wanted != got {
+		t.Errorf("wanted %s, got %s", wanted, got)
 	}
 }
 
 func TestType(t *testing.T) {
 	cmd := ShellCmd{"foo"}
 
-	expected := "dep.ShellCmd"
-	actual := cmd.Type()
+	wanted := "dep.ShellCmd"
+	got := cmd.Type()
 
-	if expected != actual {
-		t.Errorf("wanted %s, got %s", expected, actual)
+	if wanted != got {
+		t.Errorf("wanted %s, got %s", wanted, got)
 	}
 }
 
@@ -33,7 +33,7 @@ func TestTruth(t *testing.T) {
 	cmd := ShellCmd{"foo"}
 
 	if !cmd.Truth() {
-		t.Error("Truth did not return true")
+		t.Error("wanted cmd.Truth to return true; got false")
 	}
 }
 
@@ -43,11 +43,11 @@ func TestHash(t *testing.T) {
 	_, err := cmd.Hash()
 
 	if err == nil {
-		t.Fatal("expected Hash to return an error")
+		t.Fatal("wanted Hash to return an error")
 	}
 
-	if !strings.Contains(err.Error(), "unhashable type") {
-		t.Errorf("expected error to contain 'unhashable type")
+	if !strings.HasPrefix(err.Error(), "unhashable type") {
+		t.Errorf("wanted error to contain 'unhashable type")
 	}
 }
 
@@ -55,8 +55,8 @@ func TestShellCmd(t *testing.T) {
 	thread := &starlark.Thread{}
 	builtin := &starlark.Builtin{}
 
-	expectedCommand := "foo"
-	input := []starlark.Value{starlark.String(expectedCommand)}
+	want := "foo"
+	input := []starlark.Value{starlark.String(want)}
 	value, err := FnShell(thread, builtin, input, []starlark.Tuple{})
 
 	if err != nil {
@@ -68,7 +68,8 @@ func TestShellCmd(t *testing.T) {
 		t.Errorf("returned value %s was not a ShellCmd", value)
 	}
 
-	if expectedCommand != cmd.Command {
-		t.Errorf("wanted %s, got %s", expectedCommand, cmd.Command)
+	got := cmd.Command
+	if want != got {
+		t.Errorf("wanted %s, got %s", want, got)
 	}
 }


### PR DESCRIPTION
Small tweaks to error messages in tests.

Clean up redundant use of fmt.Sprintf when crafting error messages.

Signed-off-by: Nick Travers <n.e.travers@gmail.com>