### PR TITLE
Print output with color

### DIFF
--- a/cmd/print/print.go
+++ b/cmd/print/print.go
@@ -21,8 +21,10 @@ import (
 
 func main() {
 	var dir, start string
+	var disableColor bool
 	flag.StringVar(&dir, "dir", "", "the directory of files to parse")
 	flag.StringVar(&start, "start", "all", "the dependency to start from")
+	flag.BoolVar(&disableColor, "nocolor", false, "disable color in output")
 	flag.Parse()
 
 	if dir == "" {
@@ -48,9 +50,13 @@ func main() {
 	fmt.Printf("\nWalking the graph from node '%s' ...\n", start)
 	fmt.Println()
 
-	printer := g.NewDepPrinter()
-	walker := g.NewWalker(printer)
+	var printOptions []g.PrintOption
+	if !disableColor {
+		printOptions = append(printOptions, g.WithColor)
+	}
+	printer := g.NewDepPrinter(printOptions...)
 
+	walker := g.NewWalker(printer)
 	err = walker.Walk(graph, start)
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/actions/shell_action.go
+++ b/pkg/actions/shell_action.go
@@ -21,7 +21,6 @@ type ShellCommandAction struct {
 	// debug determines whether the command will output debug information to
 	// the outputWriter
 	debug bool
-
 }
 
 // NewShellCommandAction constructs and returns a new ShellCommandAction

--- a/pkg/graph/printer_test.go
+++ b/pkg/graph/printer_test.go
@@ -52,7 +52,7 @@ func TestDepPrinter_PostVisit_IsSatisfied(t *testing.T) {
 		t.Errorf("wanted indentLevel zero; got %d", printer.indentLevel)
 	}
 
-	wanted := "} foo ✔\n"
+	wanted := "} ✔ foo\n"
 	if buf.String() != wanted {
 		t.Errorf("wanted string '%s'; got %s", wanted, buf.String())
 	}
@@ -70,8 +70,50 @@ func TestDepPrinter_PostVisit_IsUnsatisfied(t *testing.T) {
 		t.Errorf("wanted indentLevel zero; got %d", printer.indentLevel)
 	}
 
-	wanted := "} foo ✖\n"
+	wanted := "} ✖ foo\n"
 	if buf.String() != wanted {
 		t.Errorf("wanted string '%s'; got %s", wanted, buf.String())
+	}
+}
+
+func TestDepPrinter_NoColor(t *testing.T) {
+	printer := depPrinter{colorize: false}
+
+	want := "foo"
+	outputs := []string{
+		printer.wrap(want, colorGreen),
+		printer.wrap(want, colorRed),
+	}
+
+	for _, output := range outputs {
+		if output != want {
+			t.Errorf("wanted plain output '%s'; got '%s'", want, output)
+		}
+	}
+}
+
+func TestDepPrinter_Color(t *testing.T) {
+	printer := depPrinter{colorize: true}
+
+	type testInput struct {
+		s     string
+		color int
+	}
+
+	inputs := []testInput{
+		{"foo", colorGreen},
+		{"foo", colorRed},
+	}
+
+	want := []string{
+		"[92mfoo[0m",
+		"[91mfoo[0m",
+	}
+
+	for i, input := range inputs {
+		got := printer.wrap(input.s, input.color)
+		if got != want[i] {
+			t.Errorf("wanted '%s'; got '%s'", want[i], got)
+		}
 	}
 }


### PR DESCRIPTION
Add color to the output of the console printer. Green is printed for
deps that are satisfied and red for deps that are unsatisfied.

Tweak formatting of output.

Signed-off-by: Nick Travers <n.e.travers@gmail.com>