### PR TITLE
Add matryoshka command

### DIFF
--- a/cmd/matryoshka/matryoshka.go
+++ b/cmd/matryoshka/matryoshka.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/nicktrav/matryoshka/pkg/graph"
+	"github.com/nicktrav/matryoshka/pkg/lang"
+)
+
+// Enforce state from dependency files in a given directory.
+//
+// Usage:
+//
+//  -dir string (required)
+//        the directory of files to parse
+//  -debug
+//        print debug output
+//  -dep string
+//        the dependency to start from (default "all")
+//  -dry-run
+//        do not run the 'meet' actions
+//  -no-color
+//        disable color in output
+//
+
+func main() {
+	var dir, dep string
+	var disableColor, dryRun, debug bool
+	flag.StringVar(&dir, "dir", "", "the directory of files to parse")
+	flag.StringVar(&dep, "dep", "all", "the dependency to start from")
+	flag.BoolVar(&disableColor, "no-color", false, "disable color in output")
+	flag.BoolVar(&debug, "debug", false, "print debug output")
+	flag.BoolVar(&dryRun, "dry-run", false, "do not run the 'meet' actions")
+	flag.Parse()
+
+	if dir == "" {
+		fmt.Println("-dir is a required argument")
+		os.Exit(1)
+	}
+
+	parser := lang.NewParser(dir)
+	err := parser.Run()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	depGraph := graph.NewDependencyGraph()
+	depGraph.Construct(parser.Deps())
+
+	var printOptions []graph.PrintOption
+	if !disableColor {
+		printOptions = append(printOptions, graph.WithColor)
+	}
+	printer := graph.NewDepPrinter(printOptions...)
+
+	var executorOptions []graph.ExecutorOption
+	if debug {
+		executorOptions = append(executorOptions, graph.Debug)
+	}
+	if dryRun {
+		executorOptions = append(executorOptions, graph.DryRun)
+	}
+	executor := graph.NewExecutor(executorOptions...)
+
+	v := graph.NewCompositeVisitor(printer, executor)
+	walker := graph.NewWalker(v)
+	err = walker.Walk(depGraph, dep)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/cmd/print/print.go
+++ b/cmd/print/print.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 
-	g "github.com/nicktrav/matryoshka/pkg/graph"
+	"github.com/nicktrav/matryoshka/pkg/graph"
 	"github.com/nicktrav/matryoshka/pkg/lang"
 )
 
@@ -14,17 +14,21 @@ import (
 //
 // Usage of ./print:
 //
-//  -dir string
+//  -dir string (required)
 //        the directory of files to parse
+//  -no-color
+//        disable color in output
 //  -start string
-//        the directory of files to parse (default "all")
+//        the dependency to start from (default "all")
+//
 
 func main() {
 	var dir, start string
 	var disableColor bool
 	flag.StringVar(&dir, "dir", "", "the directory of files to parse")
+
 	flag.StringVar(&start, "start", "all", "the dependency to start from")
-	flag.BoolVar(&disableColor, "nocolor", false, "disable color in output")
+	flag.BoolVar(&disableColor, "no-color", false, "disable color in output")
 	flag.Parse()
 
 	if dir == "" {
@@ -38,34 +42,19 @@ func main() {
 		log.Fatal(err)
 	}
 
-	graph := g.NewDependencyGraph()
-	graph.Construct(parser.Deps())
+	depGraph := graph.NewDependencyGraph()
+	depGraph.Construct(parser.Deps())
 
 	fmt.Println("Found the following dependencies:")
 	fmt.Println()
-	for i, dep := range graph.Deps() {
+	for i, dep := range depGraph.Deps() {
 		fmt.Printf("\t%3d: %s -> %s\n", i, dep.Name, getDeps(dep))
-	}
-
-	fmt.Printf("\nWalking the graph from node '%s' ...\n", start)
-	fmt.Println()
-
-	var printOptions []g.PrintOption
-	if !disableColor {
-		printOptions = append(printOptions, g.WithColor)
-	}
-	printer := g.NewDepPrinter(printOptions...)
-
-	walker := g.NewWalker(printer)
-	err = walker.Walk(graph, start)
-	if err != nil {
-		log.Fatal(err)
 	}
 }
 
 // getDeps returns a slice of names for each of the given Dependency's own
 // dependencies.
-func getDeps(dep *g.Dependency) []string {
+func getDeps(dep *graph.Dependency) []string {
 	var names []string
 	for _, d := range dep.Dependencies {
 		names = append(names, d.Name)

--- a/pkg/graph/executor_test.go
+++ b/pkg/graph/executor_test.go
@@ -200,6 +200,34 @@ func TestExecutor_EnableDebug_DebugAction(t *testing.T) {
 	}
 }
 
+func TestNewExecutor_DebugOption(t *testing.T) {
+	e := &executor{debug: false}
+
+	if e.debug {
+		t.Errorf("wanted debug 'false'; got 'true'")
+	}
+
+	Debug(e)
+
+	if !e.debug {
+		t.Errorf("wanted debug 'true'; got 'false'")
+	}
+}
+
+func TestNewExecutor_DryRunOption(t *testing.T) {
+	e := &executor{dryRun: false}
+
+	if e.dryRun {
+		t.Errorf("wanted dryRun 'false'; got 'true'")
+	}
+
+	DryRun(e)
+
+	if !e.dryRun {
+		t.Errorf("wanted dryRun 'true'; got 'false'")
+	}
+}
+
 // countingAction is an Action that counts the number of time is was called.
 type countingAction struct {
 	count int


### PR DESCRIPTION
Add new matryoshka command, that will run the main program, enforcing
dependencies.

Move dep graph printing from the "print" command, instead leaving it as
more of a debugging binary. The main matryoshka command will print the
dep graph if passed the --dry-run flag.

Refactor graph.executor to take a options in the "functional" style
(i.e. functions that can mutate the state of the target).

Signed-off-by: Nick Travers <n.e.travers@gmail.com>