### PR TITLE
Add the os() builtin function

### DIFF
--- a/pkg/lang/os.go
+++ b/pkg/lang/os.go
@@ -1,0 +1,18 @@
+package lang
+
+import (
+	"runtime"
+
+	"go.starlark.net/starlark"
+)
+
+// FnOs returns the operating system of the caller.
+//
+// The structure of `os` is as follows:
+//
+//   os()
+//
+// The functions returns the operating system, as inferred by the Go runtime.
+func FnOs(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	return starlark.String(runtime.GOOS), nil
+}

--- a/pkg/lang/os_test.go
+++ b/pkg/lang/os_test.go
@@ -1,0 +1,25 @@
+package lang
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+
+	"go.starlark.net/starlark"
+)
+
+func TestFnOs(t *testing.T) {
+	thread := &starlark.Thread{}
+	builtin := &starlark.Builtin{}
+
+	got, err := FnOs(thread, builtin, []starlark.Value{}, []starlark.Tuple{})
+	if err != nil {
+		t.Fatalf("got error running FnOs: %+v", err)
+	}
+
+	// a starlark primitive string value includes the quotes
+	want := fmt.Sprintf("\"%s\"", runtime.GOOS)
+	if got.String() != want {
+		t.Errorf("wanted %s; got %s", want, got)
+	}
+}

--- a/pkg/lang/parser.go
+++ b/pkg/lang/parser.go
@@ -2,7 +2,7 @@ package lang
 
 import (
 	"fmt"
-	"os"
+	oslib "os"
 	"path/filepath"
 
 	"go.starlark.net/starlark"
@@ -12,16 +12,20 @@ const (
 	main  = "main.dep"
 	shell = "shell"
 	dep   = "dep"
+	os    = "os"
 )
 
-var shellBuiltin = starlark.NewBuiltin(shell, FnShell)
+var (
+	shellBuiltin = starlark.NewBuiltin(shell, FnShell)
+	depBuiltin   = starlark.NewBuiltin(dep, FnDep)
+	osBuiltin    = starlark.NewBuiltin(os, FnOs)
 
-var depBuiltin = starlark.NewBuiltin(dep, FnDep)
-
-var defaultModules = starlark.StringDict{
-	shell: shellBuiltin,
-	dep:   depBuiltin,
-}
+	defaultModules = starlark.StringDict{
+		shell: shellBuiltin,
+		dep:   depBuiltin,
+		os:    osBuiltin,
+	}
+)
 
 // Parser executes a Starlark program by parsing one or more Starlark files.
 type Parser interface {
@@ -78,8 +82,8 @@ func (s cachedParser) Run() error {
 	// check for the main entrypoint
 	// TODO(nickt): remove the requirement to look for a main file
 	main := filepath.Join(s.root, main)
-	_, err := os.Stat(main)
-	if os.IsNotExist(err) {
+	_, err := oslib.Stat(main)
+	if oslib.IsNotExist(err) {
 		return fmt.Errorf("main.dep not found")
 	}
 

--- a/pkg/lang/parser_test.go
+++ b/pkg/lang/parser_test.go
@@ -1,6 +1,8 @@
 package lang
 
 import (
+	"fmt"
+	"runtime"
 	"testing"
 )
 
@@ -53,9 +55,9 @@ func TestParser_SimpleMain(t *testing.T) {
 		t.Errorf("wanted Dep 'all' to have 1 'met' command; got %d", len(dep.MetCommands))
 	}
 
-	want := "echo 'Hello, world!'"
+	want := fmt.Sprintf("echo 'Hello, %s!'", runtime.GOOS)
 	got := dep.MetCommands[0].Command
-	if dep.MetCommands[0].Command != "echo 'Hello, world!'" {
+	if dep.MetCommands[0].Command != want {
 		t.Errorf("wanted Dep 'all' 'met' command to be '%s'; got '%s'", want, got)
 	}
 

--- a/pkg/lang/testcases/simple_main/main.dep
+++ b/pkg/lang/testcases/simple_main/main.dep
@@ -13,7 +13,7 @@ all = dep(
   name = 'all',
   requires = [foo],
   met = [
-    shell("echo 'Hello, world!'")
+    shell("echo 'Hello, {}!'".format(os()))
   ],
   meet = [
     shell("echo 'Hello, indeed!'"),


### PR DESCRIPTION
Add the os() function, which will return the operating system the binary
is being run on (e.g. darwin, linux, etc.).

The os() command uses the value of runtime.GOOS to infer the operating
system.

Signed-off-by: Nick Travers <n.e.travers@gmail.com>