### PR TITLE
Add shell and login kwargs to shell()

### DIFF
--- a/pkg/actions/shell_action_test.go
+++ b/pkg/actions/shell_action_test.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/nicktrav/matryoshka/pkg/lang"
 )
 
 func TestShellCommandAction_Run_Success(t *testing.T) {
-	cmd := NewShellCommandAction("echo foo")
+	cmd := newCommand("echo foo")
 
 	err := cmd.Run()
 	if err != nil {
@@ -17,7 +19,7 @@ func TestShellCommandAction_Run_Success(t *testing.T) {
 
 func TestShellCommandAction_Run_Debug(t *testing.T) {
 	want := "foo"
-	cmd := NewShellCommandAction("echo " + want)
+	cmd := newCommand("echo " + want)
 
 	// replace stderr with our own buffer, to capture the output of the command
 	buf := new(bytes.Buffer)
@@ -38,7 +40,7 @@ func TestShellCommandAction_Run_Debug(t *testing.T) {
 }
 
 func TestShellCommandAction_Run_Fail(t *testing.T) {
-	cmd := NewShellCommandAction("false")
+	cmd := newCommand("false")
 
 	err := cmd.Run()
 	if err == nil {
@@ -53,10 +55,52 @@ func TestShellCommandAction_Run_Fail(t *testing.T) {
 
 func TestShellCommandAction_String(t *testing.T) {
 	command := "foo bar"
-	cmd := NewShellCommandAction(command)
+	cmd := newCommand(command)
 
 	wanted := "[sh]: " + command
 	if wanted != cmd.String() {
 		t.Errorf("wanted %s, got %s", wanted, cmd)
 	}
+}
+
+func TestNewShellCommandAction(t *testing.T) {
+	inputs := []*lang.ShellCmd{
+		{Command: "foo", Shell: "bash", Login: false},
+		{Command: "foo", Shell: "sh", Login: false},
+		{Command: "foo", Shell: "bash", Login: true},
+	}
+
+	type testResult struct {
+		command string
+		shell   string
+		login   bool
+	}
+	want := []testResult{
+		{"foo", "bash", false},
+		{"foo", "sh", false},
+		{"foo", "bash", true},
+	}
+
+	for i, input := range inputs {
+		command := want[i].command
+		if command != input.Command {
+			t.Errorf("wanted command %s; got %s", command, input.Command)
+		}
+
+		shell := want[i].shell
+		if shell != input.Shell {
+			t.Errorf("wanted shell %s; got %s", shell, input.Shell)
+		}
+
+		login := want[i].login
+		if login != input.Login {
+			t.Errorf("wanted login %v; got %v", login, input.Login)
+		}
+	}
+}
+
+// newCommand returns a pointer to a new ShellCommandAction running the given
+// command in a "sh" shell.
+func newCommand(command string) *ShellCommandAction {
+	return NewShellCommandAction(&lang.ShellCmd{Command: command, Shell: "sh"})
 }

--- a/pkg/graph/graph.go
+++ b/pkg/graph/graph.go
@@ -90,7 +90,7 @@ func (g *DependencyGraph) Deps() []*Dependency {
 func convertCommands(shellCommands []*lang.ShellCmd) []actions.Action {
 	var as []actions.Action
 	for _, command := range shellCommands {
-		shell := actions.NewShellCommandAction(command.Command)
+		shell := actions.NewShellCommandAction(command)
 		as = append(as, shell)
 	}
 	return as

--- a/pkg/lang/dep_test.go
+++ b/pkg/lang/dep_test.go
@@ -143,9 +143,9 @@ func TestAsRequirementsList_NotList(t *testing.T) {
 
 func TestAsCommandList(t *testing.T) {
 	cmdItems := []ShellCmd{
-		{"foo"},
-		{"bar"},
-		{"baz"},
+		{Shell: "foo"},
+		{Shell: "bar"},
+		{Shell: "baz"},
 	}
 	var values []starlark.Value
 	for _, item := range cmdItems {

--- a/pkg/lang/shell.go
+++ b/pkg/lang/shell.go
@@ -6,20 +6,34 @@ import (
 	"go.starlark.net/starlark"
 )
 
+const (
+	shellArg     = starlark.String("shell")
+	defaultShell = "bash"
+
+	loginArg = starlark.String("login")
+)
+
 // ShellCmd represents the `shell()` builtin function and represents a command
 // to run as a shell subprocess.
 //
 // The structure of `shell` is as follows:
 //
 //   shell(
-//     'echo 42', // the shell command to run
+//     'echo 42',   // the shell command to run
+//     shell='bash' // the shell to run the command in (defaults to 'bash')
+//     login=False  // the shell is a login shell (defaults to 'False')
 //   )
 //
 // TODO(nickt): Support varargs
 type ShellCmd struct {
-
 	// Command is the shell command to execute.
 	Command string
+
+	// Shell is the shell to run the command in.
+	Shell string
+
+	// Login indicates whether this command should run in a login shell or not.
+	Login bool
 }
 
 // String returns the string representation of the ShellCmd.
@@ -54,9 +68,34 @@ func FnShell(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwar
 		return nil, fmt.Errorf("expected %v to be ok type String", value)
 	}
 
-	shell := ShellCmd{
-		Command: string(strValue),
+	shell := defaultShell
+	login := false
+	for _, kwarg := range kwargs {
+		key := kwarg.Index(0)
+		value := kwarg.Index(1)
+		switch key {
+
+		case shellArg:
+			s, ok := starlark.AsString(value)
+			if !ok {
+				return nil, fmt.Errorf("shell: argument to shell is not a string")
+			}
+			shell = s
+
+		case loginArg:
+			s, ok := value.(starlark.Bool)
+			if !ok {
+				return nil, fmt.Errorf("shell: argument to login is not a boolean")
+			}
+			login = s == starlark.True
+		}
 	}
 
-	return shell, nil
+	cmd := ShellCmd{
+		Command: string(strValue),
+		Shell:   shell,
+		Login:   login,
+	}
+
+	return cmd, nil
 }


### PR DESCRIPTION
Allow for the shell to be specified by passing the 'shell' kwarg to the
shell() command with a string specifying the shell to use. Defaults to
"bash".

Allow for a login shell to be specified by passing the 'login' kwarg to
the shell() command with either True or False. Defaults to "False".

Signed-off-by: Nick Travers <n.e.travers@gmail.com>