### PR TITLE
Fix login option

### DIFF
--- a/pkg/actions/shell_action.go
+++ b/pkg/actions/shell_action.go
@@ -47,7 +47,7 @@ func NewShellCommandAction(cmd *lang.ShellCmd) *ShellCommandAction {
 func (s *ShellCommandAction) Run() error {
 	var args []string
 	if s.login {
-		args = append(args, "-i")
+		args = append(args, "-l")
 	}
 	args = append(args, "-c", s.command)
 


### PR DESCRIPTION
Bash takes the '-l' flag for login, rather than '-i', which is for
interactive.

Signed-off-by: Nick Travers <n.e.travers@gmail.com>