### PR TITLE
Add filtering of deps

### DIFF
--- a/pkg/graph/graph_test.go
+++ b/pkg/graph/graph_test.go
@@ -51,6 +51,29 @@ func TestDependencyGraph_Construct(t *testing.T) {
 	assertMapContainsDep(t, g, "boom", boomDep)
 }
 
+func TestDependencyGraph_Construct_DisabledTopLevelDep(t *testing.T) {
+	g := NewDependencyGraph()
+	g.Construct([]*lang.Dep{excludedDep})
+
+	// graph contains no deps
+	if len(g.Deps()) != 0 {
+		t.Fatalf("wanted no entries in the graph; got %+v", g.Deps())
+	}
+}
+
+func TestDependencyGraph_Construct_DisabledRequirement(t *testing.T) {
+	g := NewDependencyGraph()
+	fooRawDep.Requirements = append(fooRawDep.Requirements, excludedDep)
+	g.Construct([]*lang.Dep{fooRawDep})
+
+	// graph does not contain the excluded dep
+	for _, dep := range g.depMap {
+		if dep.Name == excludedDep.Name {
+			t.Errorf("did not expect excluded dep")
+		}
+	}
+}
+
 func assertMapContainsDep(t *testing.T, g *DependencyGraph, depName string, wantedDep *Dependency) {
 	dep, found := g.depMap[depName]
 

--- a/pkg/graph/test_fixtures.go
+++ b/pkg/graph/test_fixtures.go
@@ -7,6 +7,7 @@ var fooRawDep = &lang.Dep{
 	Requirements: []*lang.Dep{barRawDep, bamRawDep},
 	MetCommands:  []*lang.ShellCmd{},
 	MeetCommands: []*lang.ShellCmd{},
+	Enable:       true,
 }
 
 var barRawDep = &lang.Dep{
@@ -14,6 +15,7 @@ var barRawDep = &lang.Dep{
 	Requirements: []*lang.Dep{bazRawDep, boomRawDep},
 	MetCommands:  []*lang.ShellCmd{},
 	MeetCommands: []*lang.ShellCmd{},
+	Enable:       true,
 }
 
 var bazRawDep = &lang.Dep{
@@ -21,6 +23,7 @@ var bazRawDep = &lang.Dep{
 	Requirements: []*lang.Dep{},
 	MetCommands:  []*lang.ShellCmd{},
 	MeetCommands: []*lang.ShellCmd{},
+	Enable:       true,
 }
 
 var bamRawDep = &lang.Dep{
@@ -28,6 +31,7 @@ var bamRawDep = &lang.Dep{
 	Requirements: []*lang.Dep{boomRawDep},
 	MetCommands:  []*lang.ShellCmd{},
 	MeetCommands: []*lang.ShellCmd{},
+	Enable:       true,
 }
 
 var boomRawDep = &lang.Dep{
@@ -35,4 +39,10 @@ var boomRawDep = &lang.Dep{
 	Requirements: []*lang.Dep{},
 	MetCommands:  []*lang.ShellCmd{},
 	MeetCommands: []*lang.ShellCmd{},
+	Enable:       true,
+}
+
+var excludedDep = &lang.Dep{
+	Name:   "excluded",
+	Enable: false,
 }

--- a/pkg/lang/dep_test.go
+++ b/pkg/lang/dep_test.go
@@ -203,3 +203,28 @@ func TestAsCommandList_NotList(t *testing.T) {
 		}
 	}
 }
+
+func TestAsBool(t *testing.T) {
+	type testCase struct {
+		value          starlark.Value
+		errorExpected  bool
+		resultExpected bool
+	}
+	testCases := []testCase{
+		{starlark.String("foo"), true, false},
+		{starlark.Bool(true), false, true},
+		{starlark.Bool(false), false, false},
+	}
+
+	for _, testCase := range testCases {
+		res, err := asBool(testCase.value)
+
+		if testCase.errorExpected && err == nil {
+			t.Error("expected an error for input", testCase)
+		}
+
+		if !testCase.errorExpected && res != testCase.resultExpected {
+			t.Error("expected", testCase.resultExpected, "got", res)
+		}
+	}
+}

--- a/pkg/lang/parser_test.go
+++ b/pkg/lang/parser_test.go
@@ -30,12 +30,12 @@ func TestParser_SimpleMain(t *testing.T) {
 
 	err := parser.Run()
 	if err != nil {
-		t.Errorf("did not expect error %s", err)
+		t.Fatalf("did not expect error %s", err)
 	}
 
 	deps := parser.Deps()
 	if len(deps) != 2 {
-		t.Errorf("wanted 2 deps, got %d", len(deps))
+		t.Fatalf("wanted 2 deps, got %d", len(deps))
 	}
 
 	dep := pluckDep("all", deps)
@@ -94,6 +94,10 @@ func TestParser_SimpleMain(t *testing.T) {
 
 	if len(dep.MeetCommands) != 0 {
 		t.Errorf("wanted Dep 'foo' to have 0 'meet' command; got %d", len(dep.MeetCommands))
+	}
+
+	if !dep.Enable {
+		t.Error("wanted enable value", true, "got", dep.Enable)
 	}
 }
 

--- a/pkg/lang/testcases/simple_main/main.dep
+++ b/pkg/lang/testcases/simple_main/main.dep
@@ -7,6 +7,7 @@ foo = dep(
   ],
   meet = [
   ],
+  enable = True,
 )
 
 all = dep(


### PR DESCRIPTION
Add the ability to filter whether a Dep is included in the dependency
graph based on whether it passes an "enable" predicate. This allows for
deps to be included in .dep files, but excluded at graph generation
time.

Signed-off-by: Nick Travers <n.e.travers@gmail.com>