### PR TITLE
Add version subcommand

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,5 +6,4 @@ jobs:
 
     steps:
       - checkout
-      - run: go test -race -v ./...
-      - run: go vet -v ./...
+      - run: make test-all

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+bin/
 
 # Test binary, build with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,57 @@
+#-----------------------------------------------------------------------------
+# Target: setup
+#-----------------------------------------------------------------------------
+
+.PHONY: get
+get: ## Fetch all dependencies
+	go get ./...
+
+#-----------------------------------------------------------------------------
+# Target: tests
+#-----------------------------------------------------------------------------
+
+.PHONY: fmt
+fmt: ## Format all files
+	gofmt -w .
+
+.PHONY: vet
+vet: ## Run go vet
+	go vet ./...
+
+.PHONY: test
+test: ## Run all tests
+	go test -v ./...
+
+.PHONY: test-race
+test-race: ## Run the race detector
+	go test -race -v ./...
+
+test-all: fmt vet test test-race ## Run all tests, linters and formatters
+
+#-----------------------------------------------------------------------------
+# Target: artifacts
+#-----------------------------------------------------------------------------
+
+BINARY=matryoshka
+BINDIR=$(CURDIR)/bin
+
+bin: ## Creates the directory for binaries
+	mkdir ${BINDIR}
+
+VERSION=`git rev-parse HEAD`
+LDFLAGS=-ldflags "-X github.com/nicktrav/matryoshka/cmd/version.BuildCommit=${VERSION}"
+
+.PHONY: dist
+dist: ${BINDIR} ## Builds the matryoshka binary
+	go build ${LDFLAGS} -o ${BINDIR}/${BINARY} $(CURDIR)/cmd/main.go
+
+.PHONY: install
+install: dist ## Installs the binary into the GOBIN
+	cp ${BINDIR}/${BINARY} ${GOBIN}/
+
+#-----------------------------------------------------------------------------
+# Target: help
+#-----------------------------------------------------------------------------
+.PHONY: help
+help: ## Display this help text
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/nicktrav/matryoshka/cmd/apply"
 	"github.com/nicktrav/matryoshka/cmd/print"
+	"github.com/nicktrav/matryoshka/cmd/version"
 )
 
 const commandName = "matryoshka"
@@ -28,6 +29,7 @@ func newCommand(args []string) *cobra.Command {
 	rootCmd.SetArgs(args)
 	rootCmd.AddCommand(print.NewCommand())
 	rootCmd.AddCommand(apply.NewCommand())
+	rootCmd.AddCommand(version.NewCommand())
 
 	return rootCmd
 }

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -1,0 +1,23 @@
+package version
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// BuildCommit is the commit at which the binary was build. The value is
+// provided at build time via -ldflags passed to `go build`.
+var BuildCommit string
+
+// NewCommand returns a new command for fetching the version of the binary.
+func NewCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "The version of matryoshka",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Println(BuildCommit)
+			return nil
+		},
+	}
+}


### PR DESCRIPTION
Add the `matryoshka version` subcommand that prints the SHA at which the
binary was built.

Add a makefile to simplify common tasks.

Signed-off-by: Nick Travers <n.e.travers@gmail.com>